### PR TITLE
Changed default AP ESSID

### DIFF
--- a/packages/lime-system/files/etc/config/lime-defaults
+++ b/packages/lime-system/files/etc/config/lime-defaults
@@ -22,7 +22,7 @@ config lime wifi
 	option channel_5ghz '48'
 	list modes 'ap'
 	list modes 'adhoc'
-	option ap_ssid 'LiMe'
+	option ap_ssid 'libre-mesh.org'
 	option adhoc_ssid '%H'
 	option adhoc_bssid 'ca:fe:00:c0:ff:ee'
 	option adhoc_mcast_rate_2ghz '24000'


### PR DESCRIPTION
I propose to use "libre-mesh.org" as default ESSID for the AP interface. 
The contained concept is not different from the previous "LiMe" ESSID but the information contained is much more accessible.