### PR TITLE
Add olsr and olsr6 to default protocol list

### DIFF
--- a/packages/lime-system/files/etc/config/lime
+++ b/packages/lime-system/files/etc/config/lime
@@ -26,6 +26,8 @@
 #	list protocols anygw
 #	list protocols batadv:%N1                                              # Parametrizable with %Nn (which depends from ap_ssid), note that this will range between 16 and 272
 #	list protocols bmx6:13
+#	list protocols olsr:14
+#	list protocols olsr6:15
 #	list resolvers 8.8.8.8                                                 # DNS servers node will use
 #	list resolvers 2001:4860:4860::8844
 
@@ -61,7 +63,7 @@
 
 
 ### Network interface specific options ( override general option )
-### Available protocols: bmx6, batadv, wan, lan, manual
+### Available protocols: bmx6, batadv, olsr, olsr6, wan, lan, manual
 ### proto:vlan_number works too ( something like bmx6:13 is supported )
 ### If you use manual do not specify other protocols, may result in an unpredictable behavior/configuration (likely you loose connection to the node)
 

--- a/packages/lime-system/files/etc/config/lime-defaults
+++ b/packages/lime-system/files/etc/config/lime-defaults
@@ -15,6 +15,8 @@ config lime network
 	list protocols anygw
 	list protocols batadv:%N1
 	list protocols bmx6:13
+	list protocols olsr:14
+	list protocols olsr6:15
 	list resolvers 8.8.8.8
 	list resolvers 2001:4860:4860::8844
 


### PR DESCRIPTION
Inserted olsr and olsr6 in the default routing protocols list.
This pull request is closely related to #9.
VLAN 14 and 15 were chosen to not conflict with BATMAN-adv ones, see discussion on #10.