### PR TITLE
Olsrd with no VLAN

### DIFF
--- a/packages/lime-proto-olsr/src/olsr.lua
+++ b/packages/lime-proto-olsr/src/olsr.lua
@@ -47,7 +47,7 @@ function olsr.setup_interface(ifname, args)
 	local owrtInterfaceName, linux802adIfName, owrtDeviceName
 	owrtInterfaceName = ifname
 
-	if vlanId ~= 0 then
+	if vlanId ~= '0' then
 		owrtInterfaceName, linux802adIfName, owrtDeviceName = network.createVlanIface(ifname, vlanId, nameSuffix, vlanProto)
 	end
 


### PR DESCRIPTION
The script was checking when the vlan is is equal to 0, but since it came from the configuration file it should be '0'.

For legacy purpose we need to use olsrd without vlan.
Without creating a new vlan inteface, olsrd will listen on  eth0 and eth1 and wlan0_adhoc.
Generating the olsrd config i get this error:

<code>
olsrd: /etc/init.d/olsrd: olsrd_write_interface() Warning: Interface 'eth1' not found, skipped
olsrd: /etc/init.d/olsrd: olsrd_write_interface() Warning: Interface 'eth0' not found, skipped
olsrd: /etc/init.d/olsrd: olsrd_write_interface() Warning: Interface 'wlan0_adhoc' not found, skipped
</code>

The /etc/config/network doesn't contains these interface's configurations.
I Think thath this happens because the function "createVlanIface" isn't called, we need a similar function for !vlan interfaces.