### PR TITLE
Shortened batman-adv-auto-gw-mode title for fitting menuconfig

### DIFF
--- a/packages/batman-adv-auto-gw-mode/Makefile
+++ b/packages/batman-adv-auto-gw-mode/Makefile
@@ -16,7 +16,7 @@ include $(INCLUDE_DIR)/package.mk
 
 define Package/$(PKG_NAME)
   CATEGORY:=LiMe
-  TITLE:=Changes batman-adv gw_mode to reflect internet availability
+  TITLE:=Set batman-adv gw_mode by internet availability
   MAINTAINER:=Gui Iribarren <gui@altermundi.net>
   URL:=http://libre-mesh.org
   DEPENDS:= +kmod-batman-adv +watchping


### PR DESCRIPTION
The previous description was too large for menuconfig interface so it wasn't shown at all.