### PR TITLE
Adding masquerading to batman-adv-auto-gw-mode

### DIFF
--- a/packages/batman-adv-auto-gw-mode/Makefile
+++ b/packages/batman-adv-auto-gw-mode/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
   TITLE:=Changes batman-adv gw_mode to reflect internet availability
   MAINTAINER:=Gui Iribarren <gui@altermundi.net>
   URL:=http://libre-mesh.org
-  DEPENDS:= +kmod-batman-adv +watchping
+  DEPENDS:= +kmod-batman-adv +watchping +dnsmasq-dhcpv6
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/batman-adv-auto-gw-mode/Makefile
+++ b/packages/batman-adv-auto-gw-mode/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
   TITLE:=Changes batman-adv gw_mode to reflect internet availability
   MAINTAINER:=Gui Iribarren <gui@altermundi.net>
   URL:=http://libre-mesh.org
-  DEPENDS:= +kmod-batman-adv +watchping +dnsmasq-dhcpv6
+  DEPENDS:= +kmod-batman-adv +watchping +dnsmasq-dhcpv6 +lime-eb-ip-tables +ip
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/batman-adv-auto-gw-mode/files/etc/watchping/wan-ok.d/batman-gw
+++ b/packages/batman-adv-auto-gw-mode/files/etc/watchping/wan-ok.d/batman-gw
@@ -6,3 +6,11 @@ if grep -q "^=>" /sys/kernel/debug/batman_adv/bat0/gateways ; then
   BATTYPE=gw BATACTION=del /etc/hotplug.d/net/99-batman-gw
 fi
 batctl gw_mode server
+[ $? -eq 0 ] && {
+	# Adds a NAT rule if it does not already exist
+	iface="$(ip route get 8.8.8.8 | awk '{print $5}' | tr -d '\n')"
+	if ! iptables -v -n -L POSTROUTING -t nat | grep MASQUERADE  | grep 0.0.0.0/0 | grep -q $iface
+	then
+		iptables -A POSTROUTING -t nat -o $iface -j MASQUERADE
+	fi
+}


### PR DESCRIPTION
Up to now, deselecting the firewall package (as suggested by devs [here](http://wiki.ninux.org/Libre-Mesh#Selezionare_i_moduli_di_Libre-Mesh) and [here](http://lists.libre-mesh.org/pipermail/dev/2015-September/000642.html)) results in a non working WAN connection sharing caused by the absence of a masquerading rule.
Now batman-adv-auto-gw-mode, copying the code written by @P4u for bmx6-auto-gw-mode, can add this rule.
Also a dependency to dnsmasq-dhcpv6 was added, which was used [here](/libre-mesh/lime-packages/blob/develop/packages/batman-adv-auto-gw-mode/files/etc/hotplug.d/net/99-batman-gw#L18) in the code but not present in Makefile.