### PR TITLE
We check if vlan is=0 to disable it. For lime-proto-olsr6.

### DIFF
--- a/packages/lime-proto-olsr6/src/olsr6.lua
+++ b/packages/lime-proto-olsr6/src/olsr6.lua
@@ -47,7 +47,7 @@ function olsr.setup_interface(ifname, args)
 	local owrtInterfaceName, linux802adIfName, owrtDeviceName
 	owrtInterfaceName = ifname
 
-	if vlanId ~= 0 then
+	if vlanId ~= '0' then
 		owrtInterfaceName, linux802adIfName, owrtDeviceName = network.createVlanIface(ifname, vlanId, nameSuffix, vlanProto)
 	end
 


### PR DESCRIPTION
This is the completion of the fix for #16 by @gabri94 