### PR TITLE
Separate IP autocompletion range from subnet

### DIFF
--- a/packages/lime-system/files/etc/config/lime
+++ b/packages/lime-system/files/etc/config/lime
@@ -1,7 +1,7 @@
 # The options marked with "# Parametrizable with %Mn, %Nn, %H"
 # can include %Mn templates that will be substituted
 # with the n'th byte of the primary_interface MAC
-# and %Nn templates that will be replaced by the n'th network-identifier byte,
+# and %Nn templates that will be replaced by the n'th (n = 1,2,3) network-identifier byte,
 # calculated from the hash of the ap_ssid value, so that all the nodes that
 # form a mesh cloud (share the same ap_ssid) will produce the same value
 # and %H template that will be replaced by hostname
@@ -19,9 +19,9 @@
 #config lime network
 #	option primary_interface eth0                                          # The mac address of this device will be used in different places
 #	option bmx6_over_batman false                                          # Disables Bmx6 meshing on top of batman
-#	option main_ipv4_address '192.0.2.0/24'                                # Parametrizable also with %Mn, %Nn. If just a network address is specified, like "192.0.2.0/24", it gets also parametrized. This works even with netmasks other than /24 or /16...
-#	option main_ipv6_address '2001:db8::%M5:%M6/64'                        # Parametrizable with %Mn, %Nn or with trailing zeroes as for IPv4
-#	list protocols adhoc                                                   # List of protocols configured by LiMe, some of these require the relative package "lime-proto-...". Note that if you set here some protocols, you overwrite the whole list of protocols set in /etc/config/lime-defaults
+#	option main_ipv4_address '192.0.2.0/24'                                # Here you have 4 possibilities: set a static IP and the subnet, like '192.0.2.1/16'; parametrize with %Mn and %Nn, and set the subnet, like '192.%N1.%M5.%M6/16'; set a whole network address (so not a specific IP) for getting the IP autocompleted in that network with bits from MAC address, this works also with netmasks other than /24 or /16, like '192.0.128.0/17' (but not valid network addresses, for example '192.0.128.0/16' or '192.0.129.0/17', won't get parametrized); set two different parameters, the first for subnet and the second for IP parametrization, like '192.0.128.0/16/17', this results in /16 subnet but IP parametrized in a /17 range.
+#	option main_ipv6_address '2001:db8::%M5:%M6/64'                        # Parametrizable in the same way as main_ipv4_address. If used, the IP autocompletion will fill maximum the last 24 bits, so specifying an IP autocompletion range bigger than /104 is not useful.
+#	list protocols adhoc                                                   # List of protocols configured by LiMe, some of these require the relative package "lime-proto-...". Note that if you set here some protocols, you overwrite the *whole* list of protocols set in /etc/config/lime-defaults
 #	list protocols lan
 #	list protocols anygw
 #	list protocols batadv:%N1                                              # Parametrizable with %Nn (which depends from ap_ssid), note that this will range between 16 and 272

--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -56,6 +56,11 @@ function network.primary_address(offset)
     local ipv4_template = config.get("network", "main_ipv4_address")
     local ipv6_template = config.get("network", "main_ipv6_address")
 
+    local ipv4_maskbits = ipv4_template:match("[^/]+/(%d+)")
+    ipv4_template = ipv4_template:gsub("/%d-/","/")
+    local ipv6_maskbits = ipv6_template:match("[^/]+/(%d+)")
+    ipv6_template = ipv6_template:gsub("/%d-/","/")
+
     ipv4_template = utils.applyMacTemplate10(ipv4_template, pm)
     ipv6_template = utils.applyMacTemplate16(ipv6_template, pm)
 
@@ -64,8 +69,13 @@ function network.primary_address(offset)
 
     local m4, m5, m6 = tonumber(pm[4], 16), tonumber(pm[5], 16), tonumber(pm[6], 16)
     local hexsuffix = utils.hex((m4 * 256*256 + m5 * 256 + m6) + offset)
-    return network.generate_host(ip.IPv4(ipv4_template), hexsuffix),
-           network.generate_host(ip.IPv6(ipv6_template), hexsuffix)
+    ipv4_template = network.generate_host(ip.IPv4(ipv4_template), hexsuffix)
+    ipv6_template = network.generate_host(ip.IPv6(ipv6_template), hexsuffix)
+
+    ipv4_template[3] = tonumber(ipv4_maskbits)
+    ipv6_template[3] = tonumber(ipv6_maskbits)
+    
+    return ipv4_template, ipv6_template
 end
 
 function network.setup_rp_filter()


### PR DESCRIPTION
Here I implemented a possible approach to #18 (Separate settings for netmask and IP range auto assignment).

Two different ranges for IP auto assignment and for subnet can be set in the same option main_ipv4_address using this format: ip.ad.dr.es/range for IP/subnet. 
For example

    option main_ipv4_address '192.0.128.0/17/16'

will set the IP address in the range 192.0.128.1-192.0.255.254 while the subnet mask will be /16 so leaving the first half of the subnet out of auto assignment range and available for static IPs.

Retrocompatibility is respected, so when the option is specified with just one "/" the patch is not having any effect.

This is just one of the possible way for solving #18, separating the two concepts in two options would also be a good idea.
