### PR TITLE
Moving documentation from lime to lime.example file

### DIFF
--- a/packages/lime-system/files/etc/config/lime
+++ b/packages/lime-system/files/etc/config/lime
@@ -1,86 +1,16 @@
-# The options marked with "# Parametrizable with %Mn, %Nn, %H"
-# can include %Mn templates that will be substituted
-# with the n'th byte of the primary_interface MAC
-# and %Nn templates that will be replaced by the n'th (n = 1,2,3) network-identifier byte,
-# calculated from the hash of the ap_ssid value, so that all the nodes that
-# form a mesh cloud (share the same ap_ssid) will produce the same value
-# and %H template that will be replaced by hostname
-# For setting a specific WAN port, don't set it globally in section "config lime network", set it in interface specific configuration "config net ..." and install the lime-proto-wan package
-# For setting the WAN port on the default WAN port (according OpenWRT), no configuration here is needed, just install the lime-hwd-openwrt-wan package.
+# Read the documentation in /etc/config/lime.example file
+# and on https://libre-mesh.org
 
 ### System options
 
-#config lime system
-#	option hostname 'LiMeNode-%M4%M5%M6'                                   # Parametrizable with %Mn
+config lime system
 
 
 ### Network general option
 
-#config lime network
-#	option primary_interface eth0                                          # The mac address of this device will be used in different places
-#	option bmx6_over_batman false                                          # Disables Bmx6 meshing on top of batman
-#	option main_ipv4_address '192.0.2.0/24'                                # Here you have 4 possibilities: set a static IP and the subnet, like '192.0.2.1/16'; parametrize with %Mn and %Nn, and set the subnet, like '192.%N1.%M5.%M6/16'; set a whole network address (so not a specific IP) for getting the IP autocompleted in that network with bits from MAC address, this works also with netmasks other than /24 or /16, like '192.0.128.0/17' (but not valid network addresses, for example '192.0.128.0/16' or '192.0.129.0/17', won't get parametrized); set two different parameters, the first for subnet and the second for IP parametrization, like '192.0.128.0/16/17', this results in /16 subnet but IP parametrized in a /17 range.
-#	option main_ipv6_address '2001:db8::%M5:%M6/64'                        # Parametrizable in the same way as main_ipv4_address. If used, the IP autocompletion will fill maximum the last 24 bits, so specifying an IP autocompletion range bigger than /104 is not useful.
-#	list protocols adhoc                                                   # List of protocols configured by LiMe, some of these require the relative package "lime-proto-...". Note that if you set here some protocols, you overwrite the *whole* list of protocols set in /etc/config/lime-defaults
-#	list protocols lan
-#	list protocols anygw
-#	list protocols batadv:%N1                                              # Parametrizable with %Nn (which depends from ap_ssid), note that this will range between 16 and 272
-#	list protocols bmx6:13
-#	list protocols olsr:14
-#	list protocols olsr6:15
-#	list resolvers 8.8.8.8                                                 # DNS servers node will use
-#	list resolvers 2001:4860:4860::8844
+config lime network
 
 
 ### WiFi general options
 
-#config lime wifi
-#	option channel_2ghz '11'
-#	option channel_5ghz '48'                                               # Check for allowed channels on https://en.wikipedia.org/wiki/List_of_WLAN_channels#5.C2.A0GHz_.28802.11a.2Fh.2Fj.2Fn.2Fac.29.5B16.5D
-#	list modes 'ap'
-#	list modes 'adhoc'
-#	option ap_ssid 'libre-mesh.org'
-#	option adhoc_ssid '%H'                                                 # Parametrizable with %M, %H
-#	option adhoc_bssid 'ca:fe:00:c0:ff:ee'
-#	option adhoc_mcast_rate_2ghz '24000'
-#	option adhoc_mcast_rate_5ghz '6000'
-#	option mesh_mesh_fwding '0'                                            # Settings needed only for 802.11s
-#	option mesh_mesh_id 'LiMe'
-
-
-### WiFi interface specific options ( override general option )
-
-#config wifi radio11
-#	list modes 'adhoc'
-#	option channel_2ghz '1'
-#	option channel_5ghz '48'
-#	option adhoc_mcast_rate '6000'
-#	option adhoc_ssid 'libre-mesh'
-#	option adhoc_bssid 'ca:fe:00:c0:ff:ee'
-
-#config wifi radio12
-#	list modes 'manual'                                                    # If you use manual protocol you must not specify other protocol, or your configuration will be broken!
-
-
-### Network interface specific options ( override general option )
-### Available protocols: bmx6, batadv, olsr, olsr6, wan, lan, manual
-### proto:vlan_number works too ( something like bmx6:13 is supported )
-### If you use manual do not specify other protocols, may result in an unpredictable behavior/configuration (likely you loose connection to the node)
-
-#config net port5                                                           # Do not put any "." in the section name
-#	option linux_name 'eth1.5'                                          # Put here the actual name of the interface
-#	list protocols 'wan'                                                # Some of these protocols require the relative package "lime-proto-..."
-
-
-### Ground routing specific sections
-### One section for each ground routing link
-### With ground routing we mean setups having Libre-Mesh on a router which is connected via cable(s), eventually through a switch, to some wireless routers running the original firmware in WDS (transparent bridge) Ap/Sta mode.
-### Likely you want to configure as many sections of ground routing with different vlan numbers or different switch ports as many connected devices in WDS mode.
-### For a detailed description have a look at http://libre-mesh.org/projects/libre-mesh/wiki/Ground_routing
-
-#config hwd_gr link1
-#	option net_dev 'eth0'                                               # Plain ethernet device on top of which 802.1q vlan will be constructed. In case of doubts rely on wiki.openwrt.org
-#	option vlan '5'                                                     # Vlan id to use for this ground routing link, use little one because cheap switch doesn't supports big ids, this will be used also as 802.1q vid
-#	option switch_dev 'switch0'                                         # These options regarding switch need to be set only if your ethernet device is connected to a switch chip. If the switch exists you can read its name (like switch0) in /etc/config/network file
-#	option switch_cpu_port '0'                                          # Refer to switch port map of your device on wiki.openwrt.org to know CPU port index
-#	list switch_ports '4'                                               # List switch ports on which you want the vlan being passed, refer to wiki.openwrt.org for correspondence with physical ports
+config lime wifi

--- a/packages/lime-system/files/etc/config/lime-defaults
+++ b/packages/lime-system/files/etc/config/lime-defaults
@@ -1,7 +1,9 @@
 # Beware this file is NOT supposed to be edited by the end user, modify /etc/config/lime instead
 # If the same configuration is contained in both /etc/config/lime and lime-defaults file, the former will prevail
 # Beware this file is not supposed to store interface specific configuration, like "config net eth0"
-# For in-line comments about the configuration, read /etc/config/lime
+
+# Read the documentation in /etc/config/lime.example file
+# and on https://libre-mesh.org
 
 config lime system
 	option hostname 'LiMeNode-%M4%M5%M6'

--- a/packages/lime-system/files/etc/config/lime.example
+++ b/packages/lime-system/files/etc/config/lime.example
@@ -1,0 +1,89 @@
+# The /etc/config/lime-defaults file contains the default configuration.
+# To configure Libre-Mesh insert options in /etc/config/lime file, these will override the default ones.
+#
+# The options marked with "Parametrizable with %Mn, %Nn, %H"
+# can include %Mn templates that will be substituted
+# with the n'th byte of the primary_interface MAC
+# and %Nn templates that will be replaced by the n'th (n = 1,2,3) network-identifier byte,
+# calculated from the hash of the ap_ssid value, so that all the nodes that
+# form a mesh cloud (share the same ap_ssid) will produce the same value
+# and %H template that will be replaced by hostname
+# For setting a specific WAN port, don't set it globally in section "config lime network", set it in interface specific configuration "config net ..." and install the lime-proto-wan package
+# For setting the WAN port on the default WAN port (according OpenWRT), no configuration here is needed, just install the lime-hwd-openwrt-wan package.
+
+### System options
+
+config lime system
+	option hostname 'LiMeNode-%M4%M5%M6'                                   # Parametrizable with %Mn
+
+
+### Network general option
+
+config lime network
+#	option primary_interface eth0                                          # The mac address of this device will be used in different places
+#	option bmx6_over_batman false                                          # Disables Bmx6 meshing on top of batman
+	option main_ipv4_address '192.0.2.0/24'                                # Here you have 4 possibilities: set a static IP and the subnet, like '192.0.2.1/16'; parametrize with %Mn and %Nn, and set the subnet, like '192.%N1.%M5.%M6/16'; set a whole network address (so not a specific IP) for getting the IP autocompleted in that network with bits from MAC address, this works also with netmasks other than /24 or /16, like '192.0.128.0/17' (but not valid network addresses, for example '192.0.128.0/16' or '192.0.129.0/17', won't get parametrized); set two different parameters, the first for subnet and the second for IP parametrization, like '192.0.128.0/16/17', this results in /16 subnet but IP parametrized in a /17 range.
+	option main_ipv6_address '2001:db8::%M5:%M6/64'                        # Parametrizable in the same way as main_ipv4_address. If used, the IP autocompletion will fill maximum the last 24 bits, so specifying an IP autocompletion range bigger than /104 is not useful.
+	list protocols adhoc                                                   # List of protocols configured by LiMe, some of these require the relative package "lime-proto-...". Note that if you set here some protocols, you overwrite the *whole* list of protocols set in /etc/config/lime-defaults
+	list protocols lan
+	list protocols anygw
+	list protocols batadv:%N1                                              # Parametrizable with %Nn (which depends from ap_ssid), note that this will range between 16 and 272
+	list protocols bmx6:13
+#	list protocols olsr:14
+#	list protocols olsr6:15
+#	list resolvers 8.8.8.8                                                 # DNS servers node will use
+#	list resolvers 2001:4860:4860::8844
+
+
+### WiFi general options
+
+config lime wifi
+#	option channel_2ghz '11'
+#	option channel_5ghz '48'                                               # Check for allowed channels on https://en.wikipedia.org/wiki/List_of_WLAN_channels#5.C2.A0GHz_.28802.11a.2Fh.2Fj.2Fn.2Fac.29.5B16.5D
+#	list modes 'ap'
+#	list modes 'adhoc'
+	option ap_ssid 'libre-mesh.org'
+#	option adhoc_ssid '%H'                                                 # Parametrizable with %M, %H
+#	option adhoc_bssid 'ca:fe:00:c0:ff:ee'
+#	option adhoc_mcast_rate_2ghz '24000'
+#	option adhoc_mcast_rate_5ghz '6000'
+#	option mesh_mesh_fwding '0'                                            # Settings needed only for 802.11s
+#	option mesh_mesh_id 'LiMe'
+
+
+### WiFi interface specific options ( override general option )
+
+#config wifi radio11
+#	list modes 'adhoc'
+#	option channel_2ghz '1'
+#	option channel_5ghz '48'
+#	option adhoc_mcast_rate '6000'
+#	option adhoc_ssid 'libre-mesh'
+#	option adhoc_bssid 'ca:fe:00:c0:ff:ee'
+
+#config wifi radio12
+#	list modes 'manual'                                                    # If you use manual protocol you must not specify other protocol, or your configuration will be broken!
+
+
+### Network interface specific options ( override general option )
+### Available protocols: bmx6, batadv, olsr, olsr6, wan, lan, manual
+### proto:vlan_number works too ( something like bmx6:13 is supported )
+### If you use manual do not specify other protocols, may result in an unpredictable behavior/configuration (likely you loose connection to the node)
+
+#config net port5                                                           # Do not put any "." in the section name
+#	option linux_name 'eth1.5'                                          # Put here the actual name of the interface
+#	list protocols 'wan'                                                # Some of these protocols require the relative package "lime-proto-..."
+
+
+### Ground routing specific sections
+### One section for each ground routing link
+### With ground routing we mean setups having Libre-Mesh on a router which is connected via cable(s), eventually through a switch, to some wireless routers running the original firmware in WDS (transparent bridge) Ap/Sta mode.
+### Likely you want to configure as many sections of ground routing with different vlan numbers or different switch ports as many connected devices in WDS mode.
+### For a detailed description have a look at http://libre-mesh.org/projects/libre-mesh/wiki/Ground_routing
+
+#config hwd_gr link1
+#	option net_dev 'eth0'                                               # Plain ethernet device on top of which 802.1q vlan will be constructed. In case of doubts rely on wiki.openwrt.org
+#	option vlan '5'                                                     # Vlan id to use for this ground routing link, use little one because cheap switch doesn't supports big ids, this will be used also as 802.1q vid
+#	option switch_dev 'switch0'                                         # These options regarding switch need to be set only if your ethernet device is connected to a switch chip. If the switch exists you can read its name (like switch0) in /etc/config/network file
+#	option switch_cpu_port '0'                                          # Refer to switch port map of your device on wiki.openwrt.org to know CPU port index
+#	list switch_ports '4'                                               # List switch ports on which you want the vlan being passed, refer to wiki.openwrt.org for correspondence with physical ports


### PR DESCRIPTION
Often happens to me that I write a configuration line in /etc/config/lime file but I forget to uncomment also the relative section name.
A newbie could even not know that uncommenting the section name is necessary.
I think that uncommenting the section names could be a convenient solution.
And it doesn't cause new errors.
