### PR TITLE
Created package with legacy luci.ip

### DIFF
--- a/packages/libluciip-lua/Makefile
+++ b/packages/libluciip-lua/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v3.
+#
+
+include $(TOPDIR)/rules.mk
+
+GIT_COMMIT_DATE:=$(shell git log -n 1 --pretty=%ad --date=short . )
+GIT_COMMIT_TSTAMP:=$(shell git log -n 1 --pretty=%at . )
+
+PKG_NAME:=libluciip-lua
+PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+	TITLE:=LuCI IP calculation library
+	SECTION:=libs
+	CATEGORY:=Libraries
+	MAINTAINER:=Ilario Gelmetti <ilario@eigenlab.org>
+	URL:=http://libre-mesh.org
+	DEPENDS:= +lua +luci-lib-nixio +luci-base
+endef
+
+define Package/$(PKG_NAME)/description
+	IP calculation library from LuCI 0.12
+	Original version can be found on
+	http://git.openwrt.org/?p=project/luci.git;a=blob;f=modules/base/luasrc/ip.lua;hb=refs/heads/luci-0.12
+endef
+
+define Build/Prepare
+        mkdir -p $(1)/usr/lib/lua
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/packages/lime-system/Makefile
+++ b/packages/lime-system/Makefile
@@ -27,7 +27,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=LiMe
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=http://libre-mesh.org
-  DEPENDS:=+lua +luabitop +libuci-lua +luci-base +luci-lib-nixio
+  DEPENDS:=+lua +luabitop +libuci-lua +luci-base +luci-lib-nixio +libluciip-lua
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -8,7 +8,7 @@ local libuci = require("uci")
 local fs = require("nixio.fs")
 local config = require("lime.config")
 local utils = require("lime.utils")
-local ip_legacy = require("lime.ipl")
+local luciip = require("libluciip")
 
 network.limeIfNamePrefix="lm_net_"
 network.protoParamsSeparator=":"
@@ -33,7 +33,7 @@ function network.generate_host(ipprefix, hexsuffix)
     hexsuffix = hexsuffix:sub((ipprefix[1] == 4) and -8 or -32)
 
     -- convert hexsuffix into a cidr instance, using same prefix and family of ipprefix
-    local ipsuffix = ip_legacy.Hex(hexsuffix, ipprefix:prefix(), ipprefix[1])
+    local ipsuffix = luciip.Hex(hexsuffix, ipprefix:prefix(), ipprefix[1])
 
     local ipaddress = ipprefix
     -- if it's a network prefix, fill in host bits with ipsuffix
@@ -63,8 +63,8 @@ function network.primary_address(offset)
 
     local m4, m5, m6 = tonumber(pm[4], 16), tonumber(pm[5], 16), tonumber(pm[6], 16)
     local hexsuffix = utils.hex((m4 * 256*256 + m5 * 256 + m6) + offset)
-    return network.generate_host(ip_legacy.IPv4(ipv4_template), hexsuffix),
-           network.generate_host(ip_legacy.IPv6(ipv6_template), hexsuffix)
+    return network.generate_host(luciip.IPv4(ipv4_template), hexsuffix),
+           network.generate_host(luciip.IPv6(ipv6_template), hexsuffix)
 end
 
 function network.setup_rp_filter()


### PR DESCRIPTION
I moved the luci.ip library from LiMe libraries to a standalone package.

I tested this with both OpenWRT Barrier Breaker and OpenWRT Chaos Calmer and it does its work solving #7.

Indeed with Chaos Calmer also the rest of the LiMe system seems working so we should really consider to merge this also in develop branch.