### PR TITLE
Make alfred daemon start by default when using the dnsmasq-lease-share module

### DIFF
--- a/packages/dnsmasq-lease-share/files/etc/uci-defaults/90_dnsmasq-lease-share
+++ b/packages/dnsmasq-lease-share/files/etc/uci-defaults/90_dnsmasq-lease-share
@@ -3,5 +3,7 @@
 uci set dhcp.@dnsmasq[0].dhcpscript=/etc/alfred/dnsmasq-lease-share.lua
 uci set dhcp.@dnsmasq[0].dhcphostsfile=/tmp/dhcp.hosts_remote
 uci commit dhcp
+uci set alfred.alfred.disabled=0
+uci commit alfred
 
 exit 0


### PR DESCRIPTION
For the dnsmasq-lease-share module to work a running alfred is needed.
This enables its start on boot.