### PR TITLE
Added lime-hwd-ground-routing to lime-full

### DIFF
--- a/packages/lime-full/Makefile
+++ b/packages/lime-full/Makefile
@@ -26,7 +26,7 @@ define Package/$(PKG_NAME)
 		+dnsmasq-lease-share \
 		+lime-webui +luci-app-batman-adv +luci-app-bmx6 \
 		+lime-map-agent \
-		+lime-debug \
+		+lime-debug +lime-hwd-ground-routing \
 		+lime-hwd-openwrt-wan +bmx6-auto-gw-mode
 endef
 


### PR DESCRIPTION
Including *lime-hwd-ground-routing* module in lime-full will have no negative impact and will allow to configure [ground routing](http://libre-mesh.org/projects/libre-mesh/wiki/Ground_routing) set-ups.