### PR TITLE
lime-debug: add tcpdump-mini

### DIFF
--- a/packages/lime-debug/Makefile
+++ b/packages/lime-debug/Makefile
@@ -23,7 +23,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
 	URL:=http://libre-mesh.org
 	DEPENDS:=+batctl +busybox +ethtool +iwinfo +iw +mtr +ip +iputils-ping6 \
-		+sprunge +safe-reboot +netperf +pv +rdisc6
+		+sprunge +safe-reboot +netperf +pv +rdisc6 +tcpdump-mini
 endef
 
 define Package/$(PKG_NAME)/description


### PR DESCRIPTION
In my opinion tcpdump mini should be included in lime-debug.