### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Libre-Mesh firmware can be compiled either manually adding the feed to a [Op
 
 ### Using OpenWrt buildroot
 
-For a full and detailed compilation guide refer to [our wiki][6].
+For a more detailed compilation guide refer to [our wiki][6].
 
 Clone OpenWRT stable repository, nowadays is version 14.07 (Barrier Breaker).
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Libre-Mesh firmware can be compiled either manually adding the feed to a [Op
 
 ### Using OpenWrt buildroot
 
-For full and detailed compilation guide refer to [our wiki][6].
+For a full and detailed compilation guide refer to [our wiki][6].
 
 Clone OpenWRT stable repository, nowadays is version 14.07 (Barrier Breaker).
 


### PR DESCRIPTION
Used an 'a' in the section about the OpenWrt buildroot as it reads better and makes more grammatical sense.