### PR TITLE
Change to conditional dependencies for lime-proto-x

### DIFF
--- a/packages/lime-debug/Makefile
+++ b/packages/lime-debug/Makefile
@@ -22,7 +22,8 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LiMe
 	MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
 	URL:=http://libre-mesh.org
-	DEPENDS:=+batctl +busybox +ethtool +iwinfo +iw +mtr +ip +iputils-ping6 \
+	DEPENDS:=+PACKAGE_lime-proto-batadv:batctl \
+       		+busybox +ethtool +iwinfo +iw +mtr +ip +iputils-ping6 \
 		+sprunge +safe-reboot +netperf +pv +rdisc6 +tcpdump-mini
 endef
 

--- a/packages/lime-map-agent/Makefile
+++ b/packages/lime-map-agent/Makefile
@@ -22,7 +22,8 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LiMe
 	MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
 	URL:=http://libre-mesh.org
-	DEPENDS:=+libremap-agent +luci-lib-libremap-location +luci-lib-libremap-system +luci-lib-libremap-wireless +luci-lib-libremap-bmx6 +luci-app-lime-location
+	DEPENDS:=+libremap-agent +luci-lib-libremap-location +luci-lib-libremap-system +luci-lib-libremap-wireless \
+		+PACKAGE_lime-proto-bmx6:luci-lib-libremap-bmx6 +luci-app-lime-location
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/lime-webui/Makefile
+++ b/packages/lime-webui/Makefile
@@ -21,8 +21,9 @@ define Package/$(PKG_NAME)
   CATEGORY:=LiMe
   MAINTAINER:=p4u <pau@dabax.net>
   URL:=http://libre-mesh.org
-  DEPENDS:= +luci-mod-admin-full +luci-app-bmx6 \
-	+luci-app-batman-adv \
+  DEPENDS:= +luci-mod-admin-full \
+	+PACKAGE_lime-proto-bmx6:luci-app-bmx6 \
+	+PACKAGE_lime-proto-batadv:luci-app-batman-adv \
 	+luci-mod-status \
 	+uhttpd +libiwinfo-lua \
 	+luci-theme-bootstrap +luci-i18n-english


### PR DESCRIPTION
Using [conditional dependencies](https://wiki.openwrt.org/doc/devel/dependencies#dependency_types) for avoiding the selection of some routing packages when not explicitly requested.
This should solve #28 and partially #39.