### PR TITLE
Added conditional dependencies to non-lime packages and update dependency from BMX6 to BMX7

### DIFF
--- a/packages/batman-adv-auto-gw-mode/Makefile
+++ b/packages/batman-adv-auto-gw-mode/Makefile
@@ -19,7 +19,8 @@ define Package/$(PKG_NAME)
   TITLE:=Set batman-adv gw_mode by internet availability
   MAINTAINER:=Gui Iribarren <gui@altermundi.net>
   URL:=http://libre-mesh.org
-  DEPENDS:= +kmod-batman-adv +watchping +dnsmasq-dhcpv6 +lime-eb-ip-tables +ip
+  DEPENDS:= +kmod-batman-adv +watchping +dnsmasq-dhcpv6 +lime-eb-ip-tables +ip \
+	  +PACKAGE_lime-system:lime-proto-batadv
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/bmx6-auto-gw-mode/Makefile
+++ b/packages/bmx6-auto-gw-mode/Makefile
@@ -19,7 +19,8 @@ define Package/$(PKG_NAME)
   TITLE:=bmx6 auto Internet gateway module 
   MAINTAINER:=Pau Escrich <p4u@dabax.et>
   URL:=http://libre-mesh.org
-  DEPENDS:= bmx6 +watchping +lime-eb-ip-tables +ip
+  DEPENDS:= bmx6 +watchping +lime-eb-ip-tables +ip \
+	  +PACKAGE_lime-system:lime-proto-bmx6
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/bmx6-auto-gw-mode/Makefile
+++ b/packages/bmx6-auto-gw-mode/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
   TITLE:=bmx6 auto Internet gateway module 
   MAINTAINER:=Pau Escrich <p4u@dabax.et>
   URL:=http://libre-mesh.org
-  DEPENDS:= bmx6 +watchping +lime-eb-ip-tables +ip \
+  DEPENDS:= bmx7 +watchping +lime-eb-ip-tables +ip \
 	  +PACKAGE_lime-system:lime-proto-bmx6
 endef
 

--- a/packages/dnsmasq-distributed-hosts/Makefile
+++ b/packages/dnsmasq-distributed-hosts/Makefile
@@ -19,7 +19,8 @@ define Package/$(PKG_NAME)
  TITLE:=/etc/hosts sharing accross batman-adv mesh
  MAINTAINER:=Gui Iribarren <gui@altermundi.net>
  URL:=http://libre-mesh.org
- DEPENDS:=+alfred +lua +libuci-lua
+ DEPENDS:=+alfred +lua +libuci-lua \
+	 +PACKAGE_lime-system:lime-proto-batadv
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/dnsmasq-lease-share/Makefile
+++ b/packages/dnsmasq-lease-share/Makefile
@@ -19,7 +19,8 @@ define Package/$(PKG_NAME)
  TITLE:=dnsmasq lease sharing accross batman-adv mesh
  MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
  URL:=http://libre-mesh.org
- DEPENDS:=+alfred +lua +libuci-lua
+ DEPENDS:=+alfred +lua +libuci-lua \
+	 +PACKAGE_lime-system:lime-proto-batadv
 endef
 
 define Package/$(PKG_NAME)/description


### PR DESCRIPTION
Sorry for putting the two commits in the same pull requests but both commits were changing the same line.
The first is for making the optional proto related modules to select also the relative proto module when lime-system is selected. This solves also #24.
The second is for coherence with 52bfb5a.