### PR TITLE
lime_proto_olsr2

### DIFF
--- a/packages/lime-proto-olsr2/Makefile
+++ b/packages/lime-proto-olsr2/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v3.
 #
@@ -18,11 +18,11 @@ PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
 include $(INCLUDE_DIR)/package.mk
 
 define Package/$(PKG_NAME)
-	TITLE:=LiMe OLSR2 proto support (Ipv4/6)
+	TITLE:=LiMe OLSR2 proto support (IPv4/v6)
 	CATEGORY:=LiMe
-	MAINTAINER:=Gabriel <gabriel@inventati.org>
+	MAINTAINER:=Gabriel <gabriel@autistici.org>
 	URL:=http://libre-mesh.org
-	DEPENDS:=+lua +libuci-lua +lime-system +oonf_olsrd2
+	DEPENDS:=+lua +libuci-lua +lime-system +oonf-olsrd2
 endef
 
 define Build/Compile

--- a/packages/lime-proto-olsr2/Makefile
+++ b/packages/lime-proto-olsr2/Makefile
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2006-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v3.
+#
+
+include $(TOPDIR)/rules.mk
+
+LIME_BUILDDATE:=$(shell date +%Y%m%d_%H%M)
+LIME_CODENAME:=bigbang
+
+GIT_COMMIT_DATE:=$(shell git log -n 1 --pretty=%ad --date=short . )
+GIT_COMMIT_TSTAMP:=$(shell git log -n 1 --pretty=%at . )
+
+PKG_NAME:=lime-proto-olsr2
+PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+	TITLE:=LiMe OLSR2 proto support (Ipv4/6)
+	CATEGORY:=LiMe
+	MAINTAINER:=Gabriel <gabriel@inventati.org>
+	URL:=http://libre-mesh.org
+	DEPENDS:=+lua +libuci-lua +lime-system +oonf_olsrd2
+endef
+
+define Build/Compile
+	@rm -rf ./build || true
+	@cp -r ./src ./build
+	@sed -i '/^--!.*/d' build/*.lua
+endef
+
+define Package/$(PKG_NAME)/install
+	@mkdir -p $(1)/usr/lib/lua/lime/proto || true
+	$(CP) ./build/olsr2.lua $(1)/usr/lib/lua/lime/proto/
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/packages/lime-proto-olsr2/src/olsr2.lua
+++ b/packages/lime-proto-olsr2/src/olsr2.lua
@@ -1,0 +1,64 @@
+#!/usr/bin/lua
+
+local network = require("lime.network")
+local config = require("lime.config")
+local fs = require("nixio.fs")
+local libuci = require("uci")
+local wireless = require("lime.wireless")
+local utils = require("lime.utils")
+local ip = require("luci.ip")
+olsr2 = {}
+
+olsr2.configured = false
+
+function olsr2.configure(args)
+	if olsr2.configured then return end
+	olsr2.configured = true
+
+	local uci = libuci:cursor()
+	local ipv4, ipv6 = network.primary_address()
+	local origInterfaceName = network.limeIfNamePrefix.."olsr_originator_lo"
+
+	fs.writefile("/etc/config/olsrd2", "")
+	uci:set("olsrd2", "lime", "global")
+	uci:set("olsrd2", "lime", "failfast", "no")
+	uci:set("olsrd2", "lime", "pidfile", "/var/run/olsrd2.pid")
+	uci:set("olsrd2", "lime", "lockfile", "/var/lock/olsrd2")
+	uci:set("olsrd2", "lime", "olsrv2")
+	uci:set("olsrd2", "lime", "lan", {ipv4:string(), ipv6:string()})
+	uci:set("olsrd2", "limelog", "log")
+	uci:set("olsrd2", "limejson", "syslog", "true")
+	uci:set("olsrd2", "limejson", "info", "all")
+	uci:set("olsrd2", "limetelnet", "telnet")
+	uci:set("olsrd2", "limetelnet", "port", "2009")
+	uci:set("olsrd2", origInterfaceName, "interface")
+	uci:set("olsrd2", origInterfaceName, "ifname", "loopback")
+	uci:save("olsrd2")
+
+	uci:set("network", origInterfaceName, "interface")
+	uci:set("network", origInterfaceName, "ifname", "@loopback")
+	uci:set("network", origInterfaceName, "proto", "static")
+	uci:set("network", origInterfaceName, "ipaddr", ipv4:host():string())
+	uci:set("network", origInterfaceName, "netmask", "255.255.255.255")
+	uci:set("network", origInterfaceName, "ip6addr", ipv6:host():string().."/128")
+	uci:save("network")
+end
+
+function olsr2.setup_interface(ifname, args)
+	if not args["specific"] then
+		if ifname:match("^wlan%d+.ap") then return end
+	end
+	local vlanId = args[2] or 16
+	local vlanProto = args[3] or "8021ad"
+	local nameSuffix = args[4] or "_olsr"
+	local owrtInterfaceName, linux802adIfName, owrtDeviceName = network.createVlanIface(ifname, vlanId, nameSuffix, vlanProto)
+	local uci = libuci:cursor()
+
+	uci:set("olsrd2", owrtInterfaceName, "interface")
+	uci:set("olsrd2", owrtInterfaceName, "ifname", owrtInterfaceName)
+	uci:save("olsrd2")
+
+end
+
+
+return olsr2

--- a/packages/lime-system/files/etc/config/lime-defaults
+++ b/packages/lime-system/files/etc/config/lime-defaults
@@ -19,6 +19,7 @@ config lime network
 	list protocols bmx6:13
 	list protocols olsr:14
 	list protocols olsr6:15
+	list protocols olsr2:16
 	list resolvers 4.2.2.2   # b.resolvers.Level3.net
 	list resolvers 141.1.1.1 # cns1.cw.net
 	list resolvers 2001:470:20::2 # ordns.he.net

--- a/packages/lime-system/files/etc/config/lime.example
+++ b/packages/lime-system/files/etc/config/lime.example
@@ -31,6 +31,7 @@ config lime network
 	list protocols bmx6:13
 #	list protocols olsr:14
 #	list protocols olsr6:15
+#	list protocols olsr2:16
 #	list resolvers 8.8.8.8                                                 # DNS servers node will use
 #	list resolvers 2001:4860:4860::8844
 


### PR DESCRIPTION
I made a plugin to support the olsr2 routing daemon.
It will listen on the specified interfaces + loopback.
The main ip (olsr originator) is added as an alias to the loopback interface.
The local ipv4/v6 network is exported to the network.