### PR TITLE
add batctl as dependency for luci-app-batman-adv

### DIFF
--- a/packages/luci-app-batman-adv/Makefile
+++ b/packages/luci-app-batman-adv/Makefile
@@ -20,7 +20,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Gui Iribarren <gui@altermundi.net>
   SUBMENU:=3. Applications
   TITLE:=B.A.T.M.A.N.-Adv status module
-  DEPENDS:= +libc +kmod-batman-adv +luci-lib-jquery-1-4
+  DEPENDS:= +libc +kmod-batman-adv +luci-lib-jquery-1-4 +batctl
 endef
 
 define Build/Compile


### PR DESCRIPTION
batctl seems to be hardly needed for luci-app-batman-adv :)