### PR TITLE
lime-system: fix firewall work-around

### DIFF
--- a/packages/lime-system/files/etc/lime/rc.d/apply-eb-ip-rules-if-not-fw.sh
+++ b/packages/lime-system/files/etc/lime/rc.d/apply-eb-ip-rules-if-not-fw.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 [ ! -e /etc/rc.d/S??firewall ] && {
   echo "$0: Firewall is not enabled. Executing firewall.user scripts."
-  sh /etc/firewall.user.d/*
+  ( for file in /etc/firewall.user.d/* ; do . $file ; done )
 }


### PR DESCRIPTION
Execute scripts in /etc/firewall.user.d/ if firewall is not installed.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>