### PR TITLE
lime-proto-bmx6: add tunnel announcement for node own IPv6/IPv4 

### DIFF
--- a/packages/lime-proto-bmx6/src/bmx6.lua
+++ b/packages/lime-proto-bmx6/src/bmx6.lua
@@ -6,6 +6,7 @@ local fs = require("nixio.fs")
 local libuci = require("uci")
 local wireless = require("lime.wireless")
 local opkg = require("luci.model.ipkg")
+local string = require("string")
 
 bmx6 = {}
 
@@ -18,6 +19,8 @@ function bmx6.configure(args)
 
 	local uci = libuci:cursor()
 	local ipv4, ipv6 = network.primary_address()
+	local ipv4_32 = string.gsub(ipv4:string(),"/(.*)","/32")
+	local ipv6_128 = string.gsub(ipv6:string(),"/(.*)","/128")
 
 	fs.writefile("/etc/config/"..bmx6.f, "")
 
@@ -45,6 +48,16 @@ function bmx6.configure(args)
 	-- Disable ThrowRules because they are broken in IPv6 with current Linux Kernel
 	uci:set(bmx6.f, "ipVersion", "ipVersion")
 	uci:set(bmx6.f, "ipVersion", "ipVersion", "6")
+
+	-- Announce own IPv4 address
+	uci:set(bmx6.f, "myip4", "tunIn")
+	uci:set(bmx6.f, "myip4", "tunIn", "myip4")
+	uci:set(bmx6.f, "myip4", "network", ipv4_32)
+
+	-- Announce own IPv6 address
+        uci:set(bmx6.f, "myip6", "tunIn")
+        uci:set(bmx6.f, "myip6", "tunIn", "myip6")
+        uci:set(bmx6.f, "myip6", "network", ipv6_128)
 
 	-- Search for networks in 172.16.0.0/12
 	uci:set(bmx6.f, "nodes", "tunOut")


### PR DESCRIPTION
Current bmx6 tunnel configuration announces IPv4 and IPv6 network ranges but not the own node addresses. 

Having by default an announcement for /32 and /128 addresses might be usefull for users and network administration. In a network with multiple clouds where BAT-ADV is split, BMX6 would have the information to know which is the actual best path to reach the node, if not the packet will be drop in a random entry point for the destination cloud. 

In addition it help the users to know the IPv4/IPv6 of the nodes, so in a big network where the layer2 is not propagated (thus the Hostname sharing won't be useful) it facilitates the finding of node's IPs for administration or visualization. Luci-app-bmx6 will show the IP information on the "Nodes" and "Tunnels" tabs.

I don't see any negative implications for this small change. I've tested it and works fine.

Signed-off-by: p4u <p4u@dabax.net>