### PR TITLE
Add BWM-ng package to lime-debug

### DIFF
--- a/packages/lime-debug/Makefile
+++ b/packages/lime-debug/Makefile
@@ -24,7 +24,8 @@ define Package/$(PKG_NAME)
 	URL:=http://libre-mesh.org
 	DEPENDS:=+PACKAGE_lime-proto-batadv:batctl \
        		+busybox +ethtool +iwinfo +iw +mtr +ip +iputils-ping6 \
-		+sprunge +safe-reboot +netperf +pv +rdisc6 +tcpdump-mini
+		+sprunge +safe-reboot +netperf +pv +rdisc6 +tcpdump-mini \
+		+bwm-ng
 endef
 
 define Package/$(PKG_NAME)/description


### PR DESCRIPTION
This package allows to see real time traffic through each interface.
It adds _approx_ 12 KB to the image when lime-debug is included.